### PR TITLE
Get rid of www when setting up auth flow.

### DIFF
--- a/flickr.js
+++ b/flickr.js
@@ -34,7 +34,7 @@ var Client = function(apiKey, apiSecret) {
     var client = {};
     
     client.getAuthURL = function(perms) {
-        var url = 'http://www.flickr.com/services/auth/?';
+        var url = 'http://flickr.com/services/auth/?';
         var sig = getSignature(['api_key=' + apiKey,'perms=' + perms]);
         url += 'api_key=' + apiKey + '&perms=' + perms + '&api_sig=' + sig;
         return url;


### PR DESCRIPTION
Related to LockerProject/Locker#721. Currently only breaking on sandbox, and may be ephemeral, but Flickr API docs say to use http://flickr.com/, and who are we to disagree?

Have we traveled the earth and the seven seas?
